### PR TITLE
Data view verbosity header

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.2.1-preview / 2022-02-24
+
+- Added the non-verbose option for data views
+
 ## 0.2.0-preview / 2022-01-27
 
 - Updated for AVEVA Data Hub and deprecated OCSClient in favor of new ADHClient

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 0.2.0-preview
+**Version:** 0.2.1-preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-java?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2621&branchName=main)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.osisoft.ocs_sample_library_preview</groupId>
   <artifactId>ocs_sample_library_preview</artifactId>
-  <version>0.2.0-preview</version>
+  <version>0.2.1-preview</version>
 
   <name>ocs_sample_library_preview</name>
   <description>A preview of an ADH (AVEVA Data Hub) client library</description>

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/ADHClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/ADHClient.java
@@ -104,4 +104,13 @@ public class ADHClient {
     public Map<String, String> getHttpHeadersForCommunitiesRequest(String communityId) {
         return baseClient.getHttpHeadersForCommunitiesRequest(communityId);
     } 
+
+    /**
+     * Helper function to get request headers for non-verbose calls
+     * 
+     * @return Map<String,String> object with http headers
+     */
+    public Map<String, String> getHttpHeadersForNonVerboseRequest() {
+        return baseClient.getHttpHeadersForNonVerboseRequest();
+    } 
 }

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/BaseClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/BaseClient.java
@@ -195,6 +195,18 @@ public class BaseClient {
     } 
 
     /**
+     * Helper function to get request headers for a non-verbose call to the OCS API
+     * 
+     * @return Map<String,String> object with http headers
+     */
+    public Map<String, String> getHttpHeadersForNonVerboseRequest() {
+        Map<String, String> headers = getHttpHeadersForRequest();
+        headers.put("Accept-verbosity", "non-verbose");
+
+        return headers;
+    } 
+    
+    /**
      * Makes the connection to the url
      * 
      * @param url    the url to connect to

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/OCSClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/OCSClient.java
@@ -106,4 +106,14 @@ public class OCSClient {
     public Map<String, String> getHttpHeadersForCommunitiesRequest(String communityId) {
         return baseClient.getHttpHeadersForCommunitiesRequest(communityId);
     } 
+
+    
+    /**
+     * Helper function to get request headers for non-verbose calls
+     * 
+     * @return Map<String,String> object with http headers
+     */
+    public Map<String, String> getHttpHeadersForNonVerboseRequest() {
+        return baseClient.getHttpHeadersForNonVerboseRequest();
+    } 
 }

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/OCSClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/OCSClient.java
@@ -106,7 +106,6 @@ public class OCSClient {
     public Map<String, String> getHttpHeadersForCommunitiesRequest(String communityId) {
         return baseClient.getHttpHeadersForCommunitiesRequest(communityId);
     } 
-
     
     /**
      * Helper function to get request headers for non-verbose calls

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
@@ -109,18 +109,38 @@ public class DataViewClient {
         return response;
     }
 
-    private ResponseWithLinks getRequestResponseWithLinks(URL url, String method, String body, Map<String, String> headers) throws SdsError {
+    private ResponseWithLinks getRequestResponseWithLinks(URL url, String method, String body) throws SdsError {
+        
         HttpURLConnection urlConnection = null;
+
+        try {
+            urlConnection = baseClient.getConnection(url, method);
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
+
+        return getRequestResponseWithLinks(urlConnection, body);
+    }
+
+    private ResponseWithLinks getRequestResponseWithLinks(URL url, String method, String body, Map<String, String> headers) throws SdsError {
+
+        HttpURLConnection urlConnection = null;
+
+        try {
+            urlConnection = baseClient.getConnection(url, method, headers);
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
+
+        return getRequestResponseWithLinks(urlConnection, body);
+    }
+
+    private ResponseWithLinks getRequestResponseWithLinks(HttpURLConnection urlConnection, String body) throws SdsError {
+        
         ResponseWithLinks response = new ResponseWithLinks();
 
         try {
-            if (headers == null) {
-                urlConnection = baseClient.getConnection(url, method);    
-            }
-            else {
-                urlConnection = baseClient.getConnection(url, method, headers);
-            }
-
+            
             if (body != null) {
                 try (OutputStream out = new BufferedOutputStream(urlConnection.getOutputStream())) {
                     try (OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
@@ -559,7 +579,7 @@ public class DataViewClient {
             throws SdsError, MalformedURLException {
         URL url = new URL(baseUrl
                 + dataInterpolatedPath.replace("{namespaceId}", namespaceId).replace("{dataViewId}", dataViewId));
-        return getRequestResponseWithLinks(url, "GET", null, null);
+        return getRequestResponseWithLinks(url, "GET", null);
     }
 
     /**
@@ -640,7 +660,7 @@ public class DataViewClient {
             throws SdsError, MalformedURLException {
         URL url = new URL(baseUrl
                 + dataInterpolatedPath.replace("{namespaceId}", namespaceId).replace("{dataViewId}", dataViewId));
-        return getRequestResponseWithLinks(url, "GET", null, null);
+        return getRequestResponseWithLinks(url, "GET", null);
     }
 
     /**
@@ -759,16 +779,18 @@ public class DataViewClient {
     public ResponseWithLinks getDataViewInterpolatedData(String namespaceId, String dataViewId, String startIndex, String endIndex,
             String interval, String form, String cache, Integer count, Boolean verbose) throws SdsError, MalformedURLException {
 
-        Map<String, String> headers = null;
-        if(!verbose)
-        {
-            headers = baseClient.getHttpHeadersForNonVerboseRequest();
-        }
         URL url = new URL(baseUrl + getDataInterpolated.replace("{namespaceId}", namespaceId)
                 .replace("{dataViewId}", dataViewId).replace("{startIndex}", startIndex).replace("{endIndex}", endIndex)
                 .replace("{interval}", interval).replace("{form}", form).replace("{cache}", cache)
                 .replace("{count}", count.toString()));
-        return getRequestResponseWithLinks(url, "GET", null, headers);
+
+        if(!verbose)
+        {
+            Map<String, String> headers = baseClient.getHttpHeadersForNonVerboseRequest();
+            return getRequestResponseWithLinks(url, "GET", null, headers);
+        }
+
+        return getRequestResponseWithLinks(url, "GET", null);
     }
 
     /**
@@ -879,14 +901,16 @@ public class DataViewClient {
     public ResponseWithLinks getDataViewStoredData(String namespaceId, String dataViewId, String startIndex, String endIndex,
             String form, String cache, Integer count, Boolean verbose) throws SdsError, MalformedURLException {
         
-        Map<String, String> headers = null;
-        if(!verbose)
-        {
-            headers = baseClient.getHttpHeadersForNonVerboseRequest();
-        }
         URL url = new URL(baseUrl + getDataStored.replace("{namespaceId}", namespaceId)
                 .replace("{dataViewId}", dataViewId).replace("{startIndex}", startIndex).replace("{endIndex}", endIndex)
                 .replace("{form}", form).replace("{cache}", cache).replace("{count}", count.toString()));
-        return getRequestResponseWithLinks(url, "GET", null, headers);
+
+        if(!verbose)
+        {
+            Map<String, String> headers = baseClient.getHttpHeadersForNonVerboseRequest();
+            return getRequestResponseWithLinks(url, "GET", null, headers);
+        }
+        
+        return getRequestResponseWithLinks(url, "GET", null);
     }
 }

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
@@ -683,6 +683,8 @@ public class DataViewClient {
      * @param interval    The requested interval between index values. The default
      *                    value is the .DefaultInterval of the data view. Optional
      *                    if a default is specified.
+     * @param verbose     Whether the response from OCS should be verbose (containing
+     *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
      *         to the Next and First pages of data.
@@ -747,6 +749,8 @@ public class DataViewClient {
      *                    default value.
      * @param count       The requested page size. The default value is 1000. The
      *                    maximum is 250,000.
+     * @param verbose     Whether the response from OCS should be verbose (containing
+     *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
      *         to the Next and First pages of data.
@@ -801,6 +805,31 @@ public class DataViewClient {
      * @param endIndex    The requested end index, inclusive. The default value is
      *                    the .DefaultEndIndex of the data view. Optional if a
      *                    default value is specified.
+     * @param verbose     Whether the response from OCS should be verbose (containing
+     *                    values that match the default value) or not
+     * @return ResponseWithLinks, an object containing the String Response in the
+     *         requested format, and if returned by the server, also includes links
+     *         to the Next and First pages of data.
+     * @throws SdsError Error response
+     */
+    public ResponseWithLinks getDataViewStoredData(String namespaceId, String dataViewId, String startIndex, String endIndex,
+            Boolean verbose) throws SdsError, MalformedURLException {
+            
+        return getDataViewStoredData(namespaceId, dataViewId, startIndex, endIndex, "default", "Refresh", 1000, verbose);
+    }
+
+    /**
+     * Get stored data for the provided index parameters with paging. 
+     * See documentation on paging for further information.
+     *
+     * @param namespaceId The namespace identifier
+     * @param dataViewId  The data view identifier
+     * @param startIndex  The requested start index, inclusive. The default value is
+     *                    the .DefaultStartIndex of the data view. Optional if a
+     *                    default value is specified.
+     * @param endIndex    The requested end index, inclusive. The default value is
+     *                    the .DefaultEndIndex of the data view. Optional if a
+     *                    default value is specified.
      * @param form        The requested data output format. Output formats: default,
      *                    table, tableh, csv, csvh.
      * @param cache       "Refresh" to force the resource to re-resolve. "Preserve"
@@ -808,6 +837,8 @@ public class DataViewClient {
      *                    default value.
      * @param count       The requested page size. The default value is 1000. The
      *                    maximum is 250,000.
+     * @param verbose     Whether the response from OCS should be verbose (containing
+     *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
      *         to the Next and First pages of data.
@@ -815,9 +846,47 @@ public class DataViewClient {
      */
     public ResponseWithLinks getDataViewStoredData(String namespaceId, String dataViewId, String startIndex, String endIndex,
             String form, String cache, Integer count) throws SdsError, MalformedURLException {
+            
+        return getDataViewStoredData(namespaceId, dataViewId, startIndex, endIndex, form, cache, count, true);
+    }
+
+    /**
+     * Get stored data for the provided index parameters with paging. 
+     * See documentation on paging for further information.
+     *
+     * @param namespaceId The namespace identifier
+     * @param dataViewId  The data view identifier
+     * @param startIndex  The requested start index, inclusive. The default value is
+     *                    the .DefaultStartIndex of the data view. Optional if a
+     *                    default value is specified.
+     * @param endIndex    The requested end index, inclusive. The default value is
+     *                    the .DefaultEndIndex of the data view. Optional if a
+     *                    default value is specified.
+     * @param form        The requested data output format. Output formats: default,
+     *                    table, tableh, csv, csvh.
+     * @param cache       "Refresh" to force the resource to re-resolve. "Preserve"
+     *                    to use cached information, if available. "Refresh" is the
+     *                    default value.
+     * @param count       The requested page size. The default value is 1000. The
+     *                    maximum is 250,000.
+     * @param verbose     Whether the response from OCS should be verbose (containing
+     *                    values that match the default value) or not
+     * @return ResponseWithLinks, an object containing the String Response in the
+     *         requested format, and if returned by the server, also includes links
+     *         to the Next and First pages of data.
+     * @throws SdsError Error response
+     */
+    public ResponseWithLinks getDataViewStoredData(String namespaceId, String dataViewId, String startIndex, String endIndex,
+            String form, String cache, Integer count, Boolean verbose) throws SdsError, MalformedURLException {
+        
+        Map<String, String> headers = null;
+        if(!verbose)
+        {
+            headers = baseClient.getHttpHeadersForNonVerboseRequest();
+        }
         URL url = new URL(baseUrl + getDataStored.replace("{namespaceId}", namespaceId)
                 .replace("{dataViewId}", dataViewId).replace("{startIndex}", startIndex).replace("{endIndex}", endIndex)
                 .replace("{form}", form).replace("{cache}", cache).replace("{count}", count.toString()));
-        return getRequestResponseWithLinks(url, "GET", null, null);
+        return getRequestResponseWithLinks(url, "GET", null, headers);
     }
 }

--- a/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
+++ b/src/main/java/com/github/osisoft/ocs_sample_library_preview/dataviews/DataViewClient.java
@@ -703,7 +703,7 @@ public class DataViewClient {
      * @param interval    The requested interval between index values. The default
      *                    value is the .DefaultInterval of the data view. Optional
      *                    if a default is specified.
-     * @param verbose     Whether the response from OCS should be verbose (containing
+     * @param verbose     Whether the response from Data Hub should be verbose (containing
      *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
@@ -769,7 +769,7 @@ public class DataViewClient {
      *                    default value.
      * @param count       The requested page size. The default value is 1000. The
      *                    maximum is 250,000.
-     * @param verbose     Whether the response from OCS should be verbose (containing
+     * @param verbose     Whether the response from Data Hub should be verbose (containing
      *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
@@ -827,7 +827,7 @@ public class DataViewClient {
      * @param endIndex    The requested end index, inclusive. The default value is
      *                    the .DefaultEndIndex of the data view. Optional if a
      *                    default value is specified.
-     * @param verbose     Whether the response from OCS should be verbose (containing
+     * @param verbose     Whether the response from Data Hub should be verbose (containing
      *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
@@ -859,8 +859,6 @@ public class DataViewClient {
      *                    default value.
      * @param count       The requested page size. The default value is 1000. The
      *                    maximum is 250,000.
-     * @param verbose     Whether the response from OCS should be verbose (containing
-     *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links
      *         to the Next and First pages of data.
@@ -891,7 +889,7 @@ public class DataViewClient {
      *                    default value.
      * @param count       The requested page size. The default value is 1000. The
      *                    maximum is 250,000.
-     * @param verbose     Whether the response from OCS should be verbose (containing
+     * @param verbose     Whether the response from Data Hub should be verbose (containing
      *                    values that match the default value) or not
      * @return ResponseWithLinks, an object containing the String Response in the
      *         requested format, and if returned by the server, also includes links


### PR DESCRIPTION
Adds handling of a 'verbose' boolean on the data view data retrieval calls, such that verbose = false will append an accept-verbosity: non-verbose header. This should not be a breaking change since all existing call routes should map to the new route with verbose = true, which was (and is) the default.